### PR TITLE
Working with latest fpnge

### DIFF
--- a/binding/fpnge-binding.cc
+++ b/binding/fpnge-binding.cc
@@ -35,7 +35,7 @@ static PyObject* do_encode(const void* data, Py_ssize_t data_len, unsigned width
 	PyBytesObject *sv = (PyBytesObject *)Py_output_buffer;
 	
 	Py_BEGIN_ALLOW_THREADS; // TODO: do we need to add ref onto the input buffer?
-	output_len = FPNGEEncode(bits_per_channel/8, num_channels, data, width, stride, height, sv->ob_sval);
+	output_len = FPNGEEncode(bits_per_channel/8, num_channels, data, width, stride, height, sv->ob_sval, nullptr);
 	Py_END_ALLOW_THREADS;
 	
 	if (!output_len) {

--- a/binding/fpnge.cc
+++ b/binding/fpnge.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "fpnge.h"
 #include <algorithm>
 #include <assert.h>
 #include <stdint.h>
@@ -55,7 +56,20 @@
 #define MMSI(f) _mm256_##f##_si256
 #define MIVEC __m256i
 #define BCAST128 _mm256_broadcastsi128_si256
+// workaround for compilers not supporting _mm256_zextsi128_si256
+#if (defined(__clang__) && __clang_major__ >= 5 &&                             \
+     (!defined(__APPLE__) || __clang_major__ >= 7)) ||                         \
+    (defined(__GNUC__) && __GNUC__ >= 10) ||                                   \
+    (defined(_MSC_VER) && _MSC_VER >= 1910)
+#define INT2VEC(v) _mm256_zextsi128_si256(_mm_cvtsi32_si128(v))
+#elif defined(__OPTIMIZE__)
+// technically incorrect, but should work fine most of the time
 #define INT2VEC(v) _mm256_castsi128_si256(_mm_cvtsi32_si128(v))
+#else
+// _mm256_insert_epi32 is unavailable on MSVC 19.0, so prefer the following
+#define INT2VEC(v)                                                             \
+  _mm256_inserti128_si256(_mm256_setzero_si256(), _mm_cvtsi32_si128(v), 0);
+#endif
 #define SIMD_WIDTH 32
 #define SIMD_MASK 0xffffffffU
 #elif defined(__SSE4_1__)
@@ -70,6 +84,8 @@
 #else
 #error Requires SSE4.1 support minium
 #endif
+
+namespace {
 
 alignas(16) constexpr uint8_t kBitReverseNibbleLookup[16] = {
     0b0000, 0b1000, 0b0100, 0b1100, 0b0010, 0b1010, 0b0110, 0b1110,
@@ -96,6 +112,8 @@ struct HuffmanTable {
   uint8_t nbits[286];
   uint16_t end_bits;
 
+  alignas(16) uint8_t approx_nbits[16];
+
   alignas(16) uint8_t first16_nbits[16];
   alignas(16) uint8_t first16_bits[16];
 
@@ -108,6 +126,8 @@ struct HuffmanTable {
   uint32_t lz77_length_nbits[259] = {};
   uint32_t lz77_length_bits[259] = {};
   uint32_t lz77_length_sym[259] = {};
+
+  uint32_t dist_nbits, dist_bits;
 
   // Computes nbits[i] for i <= n, subject to min_limit[i] <= nbits[i] <=
   // max_limit[i], so to minimize sum(nbits[i] * freqs[i]).
@@ -194,13 +214,13 @@ struct HuffmanTable {
     }
     for (size_t i = 0; i < 14; i++) {
       collapsed_data[16 + i] = 1;
-      collapsed_min_limit[16 + i] = 8 * 0;
+      collapsed_min_limit[16 + i] = 8;
     }
     for (size_t j = 0; j < 16; j++) {
       collapsed_data[16 + 14 + j] += data[240 + j];
     }
     collapsed_data[16 + 14 + 16] = 1;
-    collapsed_min_limit[16 + 14 + 16] = 8 * 0;
+    collapsed_min_limit[16 + 14 + 16] = 8;
     collapsed_data[16 + 14 + 16 + 1] = data[285];
 
     uint8_t collapsed_nbits[48] = {};
@@ -251,25 +271,45 @@ struct HuffmanTable {
     }
   }
 
-  HuffmanTable(const uint64_t *collected_data) {
-    ComputeNBits(collected_data);
+  void FillNBits() {
+    for (size_t i = 0; i < 16; i++) {
+      first16_nbits[i] = nbits[i];
+      last16_nbits[i] = nbits[240 + i];
+    }
+    mid_nbits = nbits[16];
+    for (size_t i = 16; i < 240; i++) {
+      assert(nbits[i] == mid_nbits);
+    }
+    // Construct lz77 lookup tables.
+    for (size_t i = 0; i < 29; i++) {
+      for (size_t j = 0; j < (1U << kLZ77NBits[i]); j++) {
+        lz77_length_nbits[kLZ77Base[i] + j] = nbits[257 + i] + kLZ77NBits[i];
+        lz77_length_sym[kLZ77Base[i] + j] = 257 + i;
+      }
+    }
+
+    dist_nbits = 1;
+
+    approx_nbits[0] =
+        nbits[0] - 1; // subtract 1 as a fudge for catering for RLE
+    for (size_t i = 1; i < 15; i++) {
+      approx_nbits[i] = (nbits[i] + nbits[256 - i] + 1) / 2;
+    }
+    approx_nbits[15] = mid_nbits;
+  }
+
+  void FillBits() {
     uint16_t bits[286];
     ComputeCanonicalCode(nbits, bits);
     for (size_t i = 0; i < 16; i++) {
-      first16_nbits[i] = nbits[i];
       first16_bits[i] = bits[i];
-    }
-    for (size_t i = 0; i < 16; i++) {
-      last16_nbits[i] = nbits[240 + i];
       last16_bits[i] = bits[240 + i];
     }
-    mid_nbits = nbits[16];
     mid_lowbits[0] = mid_lowbits[15] = 0;
     for (size_t i = 16; i < 240; i += 16) {
       mid_lowbits[i / 16] = bits[i] & ((1U << (mid_nbits - 4)) - 1);
     }
     for (size_t i = 16; i < 240; i++) {
-      assert(nbits[i] == mid_nbits);
       assert((uint32_t(mid_lowbits[i / 16]) |
               (kBitReverseNibbleLookup[i % 16] << (mid_nbits - 4))) == bits[i]);
     }
@@ -277,12 +317,42 @@ struct HuffmanTable {
     // Construct lz77 lookup tables.
     for (size_t i = 0; i < 29; i++) {
       for (size_t j = 0; j < (1U << kLZ77NBits[i]); j++) {
-        lz77_length_nbits[kLZ77Base[i] + j] = nbits[257 + i] + kLZ77NBits[i];
-        lz77_length_sym[kLZ77Base[i] + j] = 257 + i;
         lz77_length_bits[kLZ77Base[i] + j] =
             bits[257 + i] | (j << nbits[257 + i]);
       }
     }
+
+    dist_bits = 0;
+  }
+
+  HuffmanTable(const uint64_t *collected_data) {
+    ComputeNBits(collected_data);
+    FillNBits();
+    FillBits();
+  }
+
+  // estimate for CollectSymbolCounts
+  // only fills nbits; skips computing actual codes
+  HuffmanTable() {
+    // the following is similar to ComputeNBits(0, 0, 0 ...), but much faster
+    constexpr uint8_t collapsed_nbits[] = {
+        2,  3,  4,  5,  5,  6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  8,
+        8,  8,  8,  8,  8,  7,  7,  7,  7,  6,  6,  6,  5,  5,  4,  3,
+
+        13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+        13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 12, 12, 12, 8};
+    for (size_t i = 0; i < 16; i++) {
+      nbits[i] = collapsed_nbits[i];
+      nbits[240 + i] = collapsed_nbits[16 + i];
+    }
+    for (size_t i = 16; i < 240; i++) {
+      nbits[i] = 12;
+    }
+    for (size_t i = 0; i < 30; i++) {
+      nbits[256 + i] = collapsed_nbits[32 + i];
+    }
+
+    FillNBits();
   }
 };
 
@@ -309,12 +379,8 @@ struct BitWriter {
   uint64_t buffer = 0;
 };
 
-static void WriteHuffmanCode(uint32_t &dist_nbits, uint32_t &dist_bits,
-                             const HuffmanTable &table,
+static void WriteHuffmanCode(const HuffmanTable &table,
                              BitWriter *__restrict writer) {
-  dist_nbits = 1;
-  dist_bits = 0;
-
   constexpr uint8_t kCodeLengthNbits[] = {
       4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0,
   };
@@ -335,7 +401,9 @@ static void WriteHuffmanCode(uint32_t &dist_nbits, uint32_t &dist_bits,
 }
 
 #ifdef __PCLMUL__
+} // namespace
 #include <wmmintrin.h>
+namespace {
 alignas(32) static const uint8_t pshufb_shf_table[] = {
     0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a,
     0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
@@ -458,10 +526,11 @@ public:
   }
 };
 #else
-
+} // namespace
 #include <array>
 #include <cstddef>
 #include <utility>
+namespace {
 // from https://joelfilho.com/blog/2020/compile_time_lookup_tables_in_cpp/
 template <std::size_t Length, typename Generator, std::size_t... Indexes>
 constexpr auto lut_impl(Generator &&f, std::index_sequence<Indexes...>) {
@@ -614,7 +683,7 @@ alignas(SIMD_WIDTH) constexpr int32_t _kMaskVec[] = {0,  0,  0,  0,
                                                      -1, -1, -1, -1,
 #endif
                                                      -1, -1, -1, -1};
-const uint8_t *kMaskVec =
+static const uint8_t *kMaskVec =
     reinterpret_cast<const uint8_t *>(_kMaskVec) + SIMD_WIDTH;
 
 template <size_t predictor, typename CB, typename CB_ADL, typename CB_RLE>
@@ -666,6 +735,31 @@ ProcessRow(size_t bytes_per_line, const unsigned char *current_row_buf,
   }
 }
 
+template <typename CB, typename CB_ADL, typename CB_RLE>
+static void
+ProcessRow(uint8_t predictor, size_t bytes_per_line,
+           const unsigned char *current_row_buf, const unsigned char *top_buf,
+           const unsigned char *left_buf, const unsigned char *topleft_buf,
+           CB &&cb, CB_ADL &&cb_adl, CB_RLE &&cb_rle) {
+  if (predictor == 1) {
+    ProcessRow<1>(bytes_per_line, current_row_buf, top_buf, left_buf,
+                  topleft_buf, cb, cb_adl, cb_rle);
+  } else if (predictor == 2) {
+    ProcessRow<2>(bytes_per_line, current_row_buf, top_buf, left_buf,
+                  topleft_buf, cb, cb_adl, cb_rle);
+  } else if (predictor == 3) {
+    ProcessRow<3>(bytes_per_line, current_row_buf, top_buf, left_buf,
+                  topleft_buf, cb, cb_adl, cb_rle);
+  } else if (predictor == 4) {
+    ProcessRow<4>(bytes_per_line, current_row_buf, top_buf, left_buf,
+                  topleft_buf, cb, cb_adl, cb_rle);
+  } else {
+    assert(predictor == 0);
+    ProcessRow<0>(bytes_per_line, current_row_buf, top_buf, left_buf,
+                  topleft_buf, cb, cb_adl, cb_rle);
+  }
+}
+
 template <typename CB> static void ForAllRLESymbols(size_t length, CB &&cb) {
   assert(length >= 4);
   length -= 1;
@@ -695,8 +789,7 @@ static void
 TryPredictor(size_t bytes_per_line, const unsigned char *current_row_buf,
              const unsigned char *top_buf, const unsigned char *left_buf,
              const unsigned char *topleft_buf, unsigned char *predicted_data,
-             const HuffmanTable &table, size_t &best_cost, uint8_t &predictor,
-             size_t dist_nbits) {
+             const HuffmanTable &table, size_t &best_cost, uint8_t &predictor) {
   size_t cost_rle = 0;
   MIVEC cost_direct = MMSI(setzero)();
   auto cost_chunk_cb = [&](const MIVEC bytes,
@@ -724,7 +817,7 @@ TryPredictor(size_t bytes_per_line, const unsigned char *current_row_buf,
   auto rle_cost_cb = [&](size_t run) {
     cost_rle += table.first16_nbits[0];
     ForAllRLESymbols(run, [&](size_t len, size_t count) {
-      cost_rle += (dist_nbits + table.lz77_length_nbits[len]) * count;
+      cost_rle += (table.dist_nbits + table.lz77_length_nbits[len]) * count;
     });
   };
   if (store_pred) {
@@ -989,31 +1082,121 @@ static FORCE_INLINE void WriteBitsShort(MIVEC nbits, MIVEC bits,
   }
 }
 
+static FORCE_INLINE void AddApproxCost(MIVEC &total, MIVEC pdata,
+                                       MIVEC bit_costs) {
+  auto approx_sym = MM(min_epu8)(MM(abs_epi8)(pdata), MM(set1_epi8)(15));
+  auto cost = MM(shuffle_epi8)(bit_costs, approx_sym);
+  total = MM(add_epi64)(total, MM(sad_epu8)(cost, MMSI(setzero)()));
+}
+static FORCE_INLINE void AddApproxCost(MIVEC &total, MIVEC pdata,
+                                       MIVEC bit_costs, MIVEC maskv) {
+  auto approx_sym = MM(min_epu8)(MM(abs_epi8)(pdata), MM(set1_epi8)(15));
+  auto cost = MM(shuffle_epi8)(bit_costs, approx_sym);
+  auto cost_mask = MMSI(and)(maskv, cost);
+  total = MM(add_epi64)(total, MM(sad_epu8)(cost, cost_mask));
+}
+
+static uint8_t
+SelectPredictor(size_t bytes_per_line, const unsigned char *current_row_buf,
+                const unsigned char *top_buf, const unsigned char *left_buf,
+                const unsigned char *topleft_buf, unsigned char *paeth_data,
+                const HuffmanTable &table, const struct FPNGEOptions *options) {
+  if (options->predictor <= 4) {
+    return options->predictor;
+  }
+  if (options->predictor == FPNGE_PREDICTOR_APPROX) {
+    auto bit_costs = BCAST128(_mm_load_si128((__m128i *)(table.approx_nbits)));
+    size_t i = 0;
+    auto cost1 = MMSI(setzero)();
+    auto cost2 = MMSI(setzero)();
+    auto cost3 = MMSI(setzero)();
+    auto cost4 = MMSI(setzero)();
+    MIVEC pdata;
+
+    for (; i + SIMD_WIDTH <= bytes_per_line; i += SIMD_WIDTH) {
+      pdata = PredictVec<1>(current_row_buf + i, top_buf + i, left_buf + i,
+                            topleft_buf + i);
+      AddApproxCost(cost1, pdata, bit_costs);
+
+      pdata = PredictVec<2>(current_row_buf + i, top_buf + i, left_buf + i,
+                            topleft_buf + i);
+      AddApproxCost(cost2, pdata, bit_costs);
+
+      pdata = PredictVec<3>(current_row_buf + i, top_buf + i, left_buf + i,
+                            topleft_buf + i);
+      AddApproxCost(cost3, pdata, bit_costs);
+
+      pdata = PredictVec<4>(current_row_buf + i, top_buf + i, left_buf + i,
+                            topleft_buf + i);
+      AddApproxCost(cost4, pdata, bit_costs);
+      MMSI(store)((MIVEC *)(paeth_data + i), pdata);
+    }
+
+    size_t bytes_remaining =
+        bytes_per_line ^ i; // equivalent to `bytes_per_line - i`
+    if (bytes_remaining) {
+      auto maskv = MMSI(loadu)((MIVEC *)(kMaskVec - bytes_remaining));
+
+      pdata = PredictVec<1>(current_row_buf + i, top_buf + i, left_buf + i,
+                            topleft_buf + i);
+      AddApproxCost(cost1, pdata, bit_costs, maskv);
+
+      pdata = PredictVec<2>(current_row_buf + i, top_buf + i, left_buf + i,
+                            topleft_buf + i);
+      AddApproxCost(cost2, pdata, bit_costs, maskv);
+
+      pdata = PredictVec<3>(current_row_buf + i, top_buf + i, left_buf + i,
+                            topleft_buf + i);
+      AddApproxCost(cost3, pdata, bit_costs, maskv);
+
+      pdata = PredictVec<4>(current_row_buf + i, top_buf + i, left_buf + i,
+                            topleft_buf + i);
+      AddApproxCost(cost4, pdata, bit_costs, maskv);
+      MMSI(store)((MIVEC *)(paeth_data + i), pdata);
+    }
+
+    uint8_t predictor = 1;
+    size_t best_cost = hadd(cost1);
+    auto test_cost = [&](MIVEC costv, uint8_t pred) {
+      size_t cost = hadd(costv);
+      if (cost < best_cost) {
+        best_cost = cost;
+        predictor = pred;
+      }
+    };
+    test_cost(cost2, 2);
+    test_cost(cost3, 3);
+    test_cost(cost4, 4);
+    return predictor;
+  }
+
+  assert(options->predictor == FPNGE_PREDICTOR_BEST);
+  uint8_t predictor;
+  size_t best_cost = ~0U;
+  TryPredictor<1, /*store_pred=*/false>(bytes_per_line, current_row_buf,
+                                        top_buf, left_buf, topleft_buf, nullptr,
+                                        table, best_cost, predictor);
+  TryPredictor<2, /*store_pred=*/false>(bytes_per_line, current_row_buf,
+                                        top_buf, left_buf, topleft_buf, nullptr,
+                                        table, best_cost, predictor);
+  TryPredictor<3, /*store_pred=*/false>(bytes_per_line, current_row_buf,
+                                        top_buf, left_buf, topleft_buf, nullptr,
+                                        table, best_cost, predictor);
+  TryPredictor<4, /*store_pred=*/true>(bytes_per_line, current_row_buf, top_buf,
+                                       left_buf, topleft_buf, paeth_data, table,
+                                       best_cost, predictor);
+  return predictor;
+}
+
 static void
 EncodeOneRow(size_t bytes_per_line, const unsigned char *current_row_buf,
              const unsigned char *top_buf, const unsigned char *left_buf,
-             const unsigned char *topleft_buf, unsigned char *predicted_data,
+             const unsigned char *topleft_buf, unsigned char *paeth_data,
              const HuffmanTable &table, uint32_t &s1, uint32_t &s2,
-             size_t dist_nbits, size_t dist_bits,
-             BitWriter *__restrict writer) {
-#ifndef FPNGE_FIXED_PREDICTOR
-  uint8_t predictor;
-  size_t best_cost = ~0U;
-  TryPredictor<1, /*store_pred=*/false>(
-      bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf, nullptr,
-      table, best_cost, predictor, dist_nbits);
-  TryPredictor<2, /*store_pred=*/false>(
-      bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf, nullptr,
-      table, best_cost, predictor, dist_nbits);
-  TryPredictor<3, /*store_pred=*/false>(
-      bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf, nullptr,
-      table, best_cost, predictor, dist_nbits);
-  TryPredictor<4, /*store_pred=*/true>(bytes_per_line, current_row_buf, top_buf,
-                                       left_buf, topleft_buf, predicted_data,
-                                       table, best_cost, predictor, dist_nbits);
-#else
-  uint8_t predictor = FPNGE_FIXED_PREDICTOR;
-#endif
+             BitWriter *__restrict writer, const struct FPNGEOptions *options) {
+  uint8_t predictor =
+      SelectPredictor(bytes_per_line, current_row_buf, top_buf, left_buf,
+                      topleft_buf, paeth_data, table, options);
 
   writer->Write(table.first16_nbits[predictor], table.first16_bits[predictor]);
   UpdateAdler32(s1, s2, predictor);
@@ -1128,51 +1311,33 @@ EncodeOneRow(size_t bytes_per_line, const unsigned char *current_row_buf,
   auto encode_rle_cb = [&](size_t run) {
     writer->Write(table.first16_nbits[0], table.first16_bits[0]);
     ForAllRLESymbols(run, [&](size_t len, size_t count) {
-      uint32_t bits = (dist_bits << table.lz77_length_nbits[len]) |
+      uint32_t bits = (table.dist_bits << table.lz77_length_nbits[len]) |
                       table.lz77_length_bits[len];
-      auto nbits = table.lz77_length_nbits[len] + dist_nbits;
+      auto nbits = table.lz77_length_nbits[len] + table.dist_nbits;
       while (count--) {
         writer->Write(nbits, bits);
       }
     });
   };
 
-#ifdef FPNGE_FIXED_PREDICTOR
-  if (predictor == 0) {
-    ProcessRow<0>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                  topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
-  } else
-#endif
-      if (predictor == 1) {
-    ProcessRow<1>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                  topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
-  } else if (predictor == 2) {
-    ProcessRow<2>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                  topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
-  } else if (predictor == 3) {
-    ProcessRow<3>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                  topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
-  } else {
-    assert(predictor == 4);
-#ifdef FPNGE_FIXED_PREDICTOR
-    ProcessRow<4>(bytes_per_line, current_row_buf, top_buf, left_buf,
-                  topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
-#else
-    // re-use predicted data from TryPredictor
-    ProcessRow<0>(bytes_per_line, predicted_data, nullptr, nullptr, nullptr,
+  if (options->predictor > 4 && predictor == 4) {
+    // re-use Paeth data
+    ProcessRow<0>(bytes_per_line, paeth_data, nullptr, nullptr, nullptr,
                   encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
-#endif
+  } else {
+    ProcessRow(predictor, bytes_per_line, current_row_buf, top_buf, left_buf,
+               topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
   }
 
   flush_adler();
 }
 
-static void CollectSymbolCounts(size_t bytes_per_line,
-                                const unsigned char *current_row_buf,
-                                const unsigned char *top_buf,
-                                const unsigned char *left_buf,
-                                const unsigned char *topleft_buf,
-                                uint64_t *__restrict symbol_counts) {
+static void
+CollectSymbolCounts(size_t bytes_per_line, const unsigned char *current_row_buf,
+                    const unsigned char *top_buf, const unsigned char *left_buf,
+                    const unsigned char *topleft_buf, unsigned char *paeth_data,
+                    uint64_t *__restrict symbol_counts,
+                    const struct FPNGEOptions *options) {
 
   auto encode_chunk_cb = [&](const MIVEC pdata, const size_t bytes_in_vec) {
     alignas(SIMD_WIDTH) uint8_t predicted_data[SIMD_WIDTH];
@@ -1212,14 +1377,25 @@ static void CollectSymbolCounts(size_t bytes_per_line,
     });
   };
 
-#ifdef FPNGE_FIXED_PREDICTOR
-  ProcessRow<FPNGE_FIXED_PREDICTOR>(bytes_per_line, current_row_buf, top_buf,
-                                    left_buf, topleft_buf, encode_chunk_cb,
-                                    adler_chunk_cb, encode_rle_cb);
-#else
-  ProcessRow<4>(bytes_per_line, current_row_buf, top_buf, left_buf, topleft_buf,
-                encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
-#endif
+  if (options->predictor == FPNGE_PREDICTOR_APPROX) {
+    // filter selection here seems to be slightly more effective when using the
+    // approximate selector; more investigation is probably warranted
+    HuffmanTable dummy_table;
+    uint8_t predictor =
+        SelectPredictor(bytes_per_line, current_row_buf, top_buf, left_buf,
+                        topleft_buf, paeth_data, dummy_table, options);
+    if (predictor == 4) {
+      ProcessRow<0>(bytes_per_line, paeth_data, nullptr, nullptr, nullptr,
+                    encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
+    } else {
+      ProcessRow(predictor, bytes_per_line, current_row_buf, top_buf, left_buf,
+                 topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
+    }
+  } else {
+    uint8_t predictor = options->predictor > 4 ? 4 : options->predictor;
+    ProcessRow(predictor, bytes_per_line, current_row_buf, top_buf, left_buf,
+               topleft_buf, encode_chunk_cb, adler_chunk_cb, encode_rle_cb);
+  }
 }
 
 static void AppendBE32(size_t value, BitWriter *__restrict writer) {
@@ -1230,7 +1406,8 @@ static void AppendBE32(size_t value, BitWriter *__restrict writer) {
 }
 
 static void WriteHeader(size_t width, size_t height, size_t bytes_per_channel,
-                        size_t num_channels, BitWriter *__restrict writer) {
+                        size_t num_channels, char cicp_colorspace,
+                        BitWriter *__restrict writer) {
   constexpr uint8_t kPNGHeader[8] = {137, 80, 78, 71, 13, 10, 26, 10};
   for (size_t i = 0; i < 8; i++) {
     writer->Write(8, kPNGHeader[i]);
@@ -1255,11 +1432,21 @@ static void WriteHeader(size_t width, size_t height, size_t bytes_per_channel,
   uint32_t crc =
       Crc32().update_final(writer->data + crc_start, crc_end - crc_start);
   AppendBE32(crc, writer);
+
+  if (cicp_colorspace == FPNGE_CICP_PQ) {
+    writer->Write(32, 0x04000000);
+    writer->Write(32, 0x50434963); // cICP
+    writer->Write(32, 0x01001009); // PQ, Rec2020
+    writer->Write(32, 0xfe23234d); // CRC
+  }
 }
+
+}  // namespace
 
 extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
                               const void *data, size_t width, size_t row_stride,
-                              size_t height, void *output) {
+                              size_t height, void *output,
+                              const struct FPNGEOptions *options) {
   assert(bytes_per_channel == 1 || bytes_per_channel == 2);
   assert(num_channels != 0 && num_channels <= 4);
   size_t bytes_per_line = bytes_per_channel * num_channels * width;
@@ -1279,21 +1466,29 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
                          ? (SIMD_WIDTH - (intptr_t)aligned_buf_ptr % SIMD_WIDTH)
                          : 0;
 
-#ifndef FPNGE_FIXED_PREDICTOR
   std::vector<unsigned char> pdata_buf(bytes_per_line_buf + SIMD_WIDTH - 1);
   unsigned char *aligned_pdata_ptr = pdata_buf.data();
   aligned_pdata_ptr +=
       (intptr_t)aligned_pdata_ptr % SIMD_WIDTH
           ? (SIMD_WIDTH - (intptr_t)aligned_pdata_ptr % SIMD_WIDTH)
           : 0;
-#else
-  unsigned char *aligned_pdata_ptr = nullptr;
-#endif
+
+  struct FPNGEOptions default_options;
+  if (options == nullptr) {
+    FPNGEFillOptions(&default_options, FPNGE_COMPRESS_LEVEL_DEFAULT,
+                     FPNGE_CICP_NONE);
+    options = &default_options;
+  }
+
+  // options sanity check
+  assert(options->predictor >= 0 && options->predictor <= FPNGE_PREDICTOR_BEST);
+  assert(options->huffman_sample >= 0 && options->huffman_sample <= 127);
 
   BitWriter writer;
   writer.data = static_cast<unsigned char *>(output);
 
-  WriteHeader(width, height, bytes_per_channel, num_channels, &writer);
+  WriteHeader(width, height, bytes_per_channel, num_channels,
+              options->cicp_colorspace, &writer);
 
   assert(writer.bits_in_buffer == 0);
   size_t chunk_length_pos = writer.bytes_written;
@@ -1306,9 +1501,12 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
 
   uint64_t symbol_counts[286] = {};
 
-  // Sample ~1.5% of the rows in the center of the image.
-  size_t y0 = height * 126 / 256;
-  size_t y1 = height * 130 / 256;
+  // Sample rows in the center of the image.
+  size_t y0 = height * (127 - options->huffman_sample) / 256;
+  size_t y1 = height * (129 + options->huffman_sample) / 256;
+  if (y1 == 0 && height > 0) { // for 1 pixel high images
+    y1 = 1;
+  }
 
   for (size_t y = y0; y < y1; y++) {
     const unsigned char *current_row_in =
@@ -1323,12 +1521,12 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
         top_buf - bytes_per_channel * num_channels;
 
     memcpy(current_row_buf, current_row_in, bytes_per_line);
-    if (y == y0) {
+    if (y == y0 && y != 0) {
       continue;
     }
 
     CollectSymbolCounts(bytes_per_line, current_row_buf, top_buf, left_buf,
-                        topleft_buf, symbol_counts);
+                        topleft_buf, aligned_pdata_ptr, symbol_counts, options);
   }
 
   memset(buf.data(), 0, buf.size());
@@ -1337,9 +1535,7 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
 
   // Single block, dynamic huffman
   writer.Write(3, 0b101);
-  uint32_t dist_nbits;
-  uint32_t dist_bits;
-  WriteHuffmanCode(dist_nbits, dist_bits, huffman_table, &writer);
+  WriteHuffmanCode(huffman_table, &writer);
 
   Crc32 crc;
   uint32_t s1 = 1;
@@ -1359,8 +1555,8 @@ extern "C" size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
     memcpy(current_row_buf, current_row_in, bytes_per_line);
 
     EncodeOneRow(bytes_per_line, current_row_buf, top_buf, left_buf,
-                 topleft_buf, aligned_pdata_ptr, huffman_table, s1, s2,
-                 dist_nbits, dist_bits, &writer);
+                 topleft_buf, aligned_pdata_ptr, huffman_table, s1, s2, &writer,
+                 options);
 
     crc_pos +=
         crc.update(writer.data + crc_pos, writer.bytes_written - crc_pos);

--- a/binding/fpnge.h
+++ b/binding/fpnge.h
@@ -19,17 +19,61 @@
 extern "C" {
 #endif
 
+enum FPNGECicpColorspace { FPNGE_CICP_NONE, FPNGE_CICP_PQ };
+
+enum FPNGEOptionsPredictor {
+  FPNGE_PREDICTOR_FIXED_NOOP,
+  FPNGE_PREDICTOR_FIXED_SUB,
+  FPNGE_PREDICTOR_FIXED_TOP,
+  FPNGE_PREDICTOR_FIXED_AVG,
+  FPNGE_PREDICTOR_FIXED_PAETH,
+  FPNGE_PREDICTOR_APPROX,
+  FPNGE_PREDICTOR_BEST
+};
+struct FPNGEOptions {
+  char predictor;        // FPNGEOptionsPredictor
+  char huffman_sample;   // 0-127: how much of the image to sample
+  char cicp_colorspace;  // FPNGECicpColorspace
+};
+
+#define FPNGE_COMPRESS_LEVEL_DEFAULT 4
+#define FPNGE_COMPRESS_LEVEL_BEST 5
+inline void FPNGEFillOptions(struct FPNGEOptions *options, int level,
+                             int cicp_colorspace) {
+  if (level == 0) level = FPNGE_COMPRESS_LEVEL_DEFAULT;
+  options->cicp_colorspace = cicp_colorspace;
+  options->huffman_sample = 1;
+  switch (level) {
+    case 1:
+      options->predictor = 2;
+      break;
+    case 2:
+      options->predictor = 4;
+      break;
+    case 3:
+      options->predictor = 5;
+      break;
+    case 5:
+      options->huffman_sample = 23;
+      // fall through
+    default:
+      options->predictor = 6;
+      break;
+  }
+}
+
 // bytes_per_channel = 1/2 for 8-bit and 16-bit. num_channels: 1/2/3/4
 // (G/GA/RGB/RGBA)
 size_t FPNGEEncode(size_t bytes_per_channel, size_t num_channels,
                    const void *data, size_t width, size_t row_stride,
-                   size_t height, void *output);
+                   size_t height, void *output,
+                   const struct FPNGEOptions *options);
 
 inline size_t FPNGEOutputAllocSize(size_t bytes_per_channel,
                                    size_t num_channels, size_t width,
                                    size_t height) {
   // likely an overestimate
-  return 1024 + 2 * bytes_per_channel * num_channels * width * height;
+  return 1024 + (2 * bytes_per_channel * width * num_channels + 1) * height;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Why?
Noticed that some large images were not encoded correctly.
### How?
Simply copy and pasted latest .h and .cc files.
Added a nullptr to the bindings to skip the new optional `FPNGEOptions` parameter.

### Result
Those images are now encoded correctly.


