### PR TITLE
Add Py_INCREF to input view

### DIFF
--- a/binding/fpnge-binding.cc
+++ b/binding/fpnge-binding.cc
@@ -81,7 +81,9 @@ PyObject* fpnge_encode_view(PyObject* self, PyObject* args) {
 	
 	if (!PyArg_ParseTuple(args, "OIIII|I", &view, &width, &height, &num_channels, &bits_per_channel, &stride))
 		return NULL;
-	
+
+	Py_INCREF(view);
+
 	if (!PyMemoryView_Check(view)) {
 		PyErr_SetString(PyExc_SystemError, "Given object is not a memoryview");
 		Py_DECREF(view);

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ class CustomBuild(build_ext):
 setup(
 	name="fpnge",
 	description="Python binding for fpnge",
-	version="1.1.1",
+	version="1.1.2",
 	author="Anime Tosho",
 	url="https://github.com/animetosho/python-fpnge/",
 	license="CC0",


### PR DESCRIPTION
Based on the following test

```
print(sys.getrefcount(view))
fpnge.fromview(view)
print(sys.getrefcount(view))
```

I think a Py_INCREF is missing in the binding.

It took me a while to realize that `.data` of numpy ndarray creates a new `memoryview`.
Therefore, if we use `sys.getrefcount(arr.data)`, the result is always 1.