### PR TITLE
Add compression level option & Get latest fpnge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ API
 
 Note: fpnge does not support indexed color or bit depths below 8 bits/pixel.
 
-fpnge.fromPIL(image)
+fpnge.fromPIL(image [, comp_level])
 ------------------------------------------------------------------
 
 Converts a PIL image specified in *image* to a PNG, returning it as a bytes object. If the image uses a palette, it will be converted to RGBA before saving.
 
-fpnge.frombytes(bytes, width, height, channels, bits_per_channel [, stride])
+fpnge.frombytes(bytes, width, height, channels, bits_per_channel [, comp_level] [, stride])
 --------------------------------------------------------------------------------
 
 Converts a raw image specified as a bytes object in *bytes* to a PNG, returning it as a bytes object.
@@ -49,7 +49,7 @@ The pixel dimensions of the supplied image must be specified in *width* and *hei
 
 No other values are allowed for *channels*
 
-fpnge.fromNP(ndarray)
+fpnge.fromNP(ndarray [, comp_level])
 --------------------------------------------------------------------------------
 
 Converts a raw image stored in a 3-dimensional NumPy *ndarray* to a PNG, returning it as a bytes object.
@@ -59,7 +59,7 @@ The element type should be a `uint8` or `'>u2'`.
 
 **Note:** This differs from the Pillow definition of `shape` which is `(width, height, channels)`
 
-## fpnge.fromview(view [, width] [, height] [, channels] [, bits_per_channel] [, stride])
+## fpnge.fromview(view [, width] [, height] [, channels] [, bits_per_channel] [, comp_level] [, stride])
 
 The `memoryview` version of `frombytes`, where *view* is a C-contiguous `memoryview`.
 

--- a/binding/fpnge-binding.cc
+++ b/binding/fpnge-binding.cc
@@ -25,7 +25,7 @@ static PyObject* do_encode(const void* data, Py_ssize_t data_len, unsigned width
 		return NULL;
 	}
 	if (comp_level > FPNGE_COMPRESS_LEVEL_BEST) {
-		PyErr_SetString(PyExc_ValueError, "Compression level must be 1-5");
+		PyErr_SetString(PyExc_ValueError, "Compression level must be 0-5");
 		return NULL;
 	}
 
@@ -116,13 +116,13 @@ static PyMethodDef fpnge_methods[] = {
 		"encode_bytes",
 		fpnge_encode_bytes,
 		METH_VARARGS,
-		"encode(image_data, width, stride, height, num_channels, bits_per_channel, comp_level)"
+		"encode_bytes(image_data, width, height, num_channels, bits_per_channel, comp_level, stride)"
 	},
 	{
 		"encode_view",
 		fpnge_encode_view,
 		METH_VARARGS,
-		"encode_view(image_data, width, stride, height, num_channels, bits_per_channel, comp_level)"
+		"encode_view(image_data, width, height, num_channels, bits_per_channel, comp_level, stride)"
 	},
 	{NULL, NULL, 0, NULL}
 };
@@ -138,5 +138,6 @@ static struct PyModuleDef fpnge_definition = {
 PyMODINIT_FUNC PyInit_binding(void) {
 	Py_Initialize();
 	PyObject* module = PyModule_Create(&fpnge_definition);
+	PyModule_AddIntConstant(module, "FPNGE_COMPRESS_LEVEL_DEFAULT", FPNGE_COMPRESS_LEVEL_DEFAULT);
 	return module;
 }

--- a/binding/fpnge-binding.cc
+++ b/binding/fpnge-binding.cc
@@ -30,7 +30,7 @@ static PyObject* do_encode(const void* data, Py_ssize_t data_len, unsigned width
 	}
 
 	struct FPNGEOptions options;
-  	FPNGEFillOptions(&options, comp_level, FPNGE_CICP_NONE);
+	FPNGEFillOptions(&options, comp_level, FPNGE_CICP_NONE);
 	
 	size_t output_len = FPNGEOutputAllocSize(bits_per_channel/8, num_channels, width, height);
 	PyObject *Py_output_buffer = PyBytes_FromStringAndSize(NULL, output_len + 1);

--- a/binding/fpnge.h
+++ b/binding/fpnge.h
@@ -30,35 +30,54 @@ enum FPNGEOptionsPredictor {
   FPNGE_PREDICTOR_APPROX,
   FPNGE_PREDICTOR_BEST
 };
+
+enum FPNGEColorChannelOrder {
+  FPNGE_ORDER_RGB,
+  FPNGE_ORDER_BGR,
+};
+
+struct FPNGEAdditionalChunk {
+  char name[4];
+  const char *data;
+  int data_size;
+};
+
 struct FPNGEOptions {
-  char predictor;        // FPNGEOptionsPredictor
-  char huffman_sample;   // 0-127: how much of the image to sample
-  char cicp_colorspace;  // FPNGECicpColorspace
+  char predictor;       // FPNGEOptionsPredictor
+  char huffman_sample;  // 0-127: how much of the image to sample
+  char cicp_colorspace; // FPNGECicpColorspace
+  char channel_order;   // FPNGEColorChannelOrder
+  int num_additional_chunks;
+  const struct FPNGEAdditionalChunk *additional_chunks;
 };
 
 #define FPNGE_COMPRESS_LEVEL_DEFAULT 4
 #define FPNGE_COMPRESS_LEVEL_BEST 5
 inline void FPNGEFillOptions(struct FPNGEOptions *options, int level,
                              int cicp_colorspace) {
-  if (level == 0) level = FPNGE_COMPRESS_LEVEL_DEFAULT;
+  if (level == 0)
+    level = FPNGE_COMPRESS_LEVEL_DEFAULT;
   options->cicp_colorspace = cicp_colorspace;
   options->huffman_sample = 1;
+  options->num_additional_chunks = 0;
+  options->additional_chunks = NULL;
+  options->channel_order = FPNGE_ORDER_RGB;
   switch (level) {
-    case 1:
-      options->predictor = 2;
-      break;
-    case 2:
-      options->predictor = 4;
-      break;
-    case 3:
-      options->predictor = 5;
-      break;
-    case 5:
-      options->huffman_sample = 23;
-      // fall through
-    default:
-      options->predictor = 6;
-      break;
+  case 1:
+    options->predictor = 2;
+    break;
+  case 2:
+    options->predictor = 4;
+    break;
+  case 3:
+    options->predictor = 5;
+    break;
+  case 5:
+    options->huffman_sample = 23;
+    // fall through
+  default:
+    options->predictor = 6;
+    break;
   }
 }
 

--- a/fpnge/__init__.py
+++ b/fpnge/__init__.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
 	from cv2 import Mat
 import fpnge.binding
 
-def fromPIL(im: 'Image', comp_level=4) -> bytes:
+def fromPIL(im: 'Image', comp_level=fpnge.binding.FPNGE_COMPRESS_LEVEL_DEFAULT) -> bytes:
 	mode_map = {
 	  "L":    (1, 8),
 	  "RGB":  (3, 8),
@@ -31,10 +31,10 @@ def fromPIL(im: 'Image', comp_level=4) -> bytes:
 	imbytes = im.tobytes()
 	return fpnge.binding.encode_bytes(imbytes, im.width, im.height, *mode_map[im.mode], comp_level)
 
-def frombytes(bytes, width, height, channels, bits_per_channel, comp_level=4, stride=0) -> bytes:
+def frombytes(bytes, width, height, channels, bits_per_channel, comp_level=fpnge.binding.FPNGE_COMPRESS_LEVEL_DEFAULT, stride=0) -> bytes:
 	return fpnge.binding.encode_bytes(bytes, width, height, channels, bits_per_channel, comp_level, stride)
 
-def fromNP(ndarray: 'NDArray', comp_level=4) -> bytes:
+def fromNP(ndarray: 'NDArray', comp_level=fpnge.binding.FPNGE_COMPRESS_LEVEL_DEFAULT) -> bytes:
 	if ndarray.ndim != 3:
 		raise AttributeError("Must have 3 dimensions (height x width x channels)")
 	if ndarray.itemsize > 1 and ndarray.dtype.byteorder != '>':
@@ -43,7 +43,7 @@ def fromNP(ndarray: 'NDArray', comp_level=4) -> bytes:
 	# This definition of shape agrees with: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.shape.html#numpy.ndarray.shape
 	return fpnge.binding.encode_view(ndarray.data, ndarray.shape[1], ndarray.shape[0], ndarray.shape[2], ndarray.dtype.itemsize * 8, comp_level)
 
-def fromMat(mat: 'Mat', comp_level=4) -> bytes:
+def fromMat(mat: 'Mat', comp_level=fpnge.binding.FPNGE_COMPRESS_LEVEL_DEFAULT) -> bytes:
 	try:
 		import cv2
 		import numpy as np
@@ -58,7 +58,7 @@ def fromMat(mat: 'Mat', comp_level=4) -> bytes:
 		mat = mat.astype('>u2')
 	return fromNP(mat, comp_level)
 
-def fromview(view: memoryview, width=0, height=0, channels=0, bits_per_channel=0, comp_level=4, stride=0) -> bytes:
+def fromview(view: memoryview, width=0, height=0, channels=0, bits_per_channel=0, comp_level=fpnge.binding.FPNGE_COMPRESS_LEVEL_DEFAULT, stride=0) -> bytes:
 	if stride == 0 and width == 0:
 		stride = view.strides[0]
 	if width == 0:


### PR DESCRIPTION
This wrapper is great! Though I found myself wanting to test out the various compression levels & predictors. These aren't exposed via the python bindings. So I went ahead and exposed them via a new argument `comp_level`.

The `comp_level` argument is added to all exposed bindings. It has a default of `4`, which is what it would have been without the argument.

This means that in `do_encode` we create the `options` struct and fill it in the exact same way which would have been happened in `FPNGEEncode` anyways when a null pointer was passed.

I've also updated the `fpnge` c++ files to match that of the fpnge repo, there have been a few updates there since this was last done.